### PR TITLE
Warn on segment size mismatch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,8 +4,8 @@ use pkg_config::find_library;
 
 fn main() -> Result<()> {
 
-    if !find_library("liblzma").is_ok() {
-        panic!("You need to install liblzma-dev. Run \"apt install liblzma-dev\"");
+    if let Err(e) = find_library("liblzma") {
+        panic!("You need to install liblzma-dev. Run \"apt install liblzma-dev\"\n\n{}", e);
 	}
 
     let mut config = Config::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn pause() {
     let _ = stdin.read(&mut [0u8]).unwrap();
 }
 
-#[derive(Tabled)]
+#[derive(Tabled, Debug)]
 pub struct MemoryRange {
     #[tabled(display_with = "display_u64")]
     pub start_phys_addr:        u64,
@@ -374,6 +374,7 @@ impl DumpItForLinux  {
             // is null when looking at "readelf -l /proc/kcore"
             // We retrieve the physical offset from /proc/iomem using the segment sizes.
             for mem_range in &self.iomem_ranges {
+                println!("mem_range: {:#X?}", mem_range);
                 if h.p_paddr(endian) == mem_range.start_phys_addr ||
                    (h.p_paddr(endian) == 0 && h.p_filesz(endian) == mem_range.memsz) ||
                    (h.p_paddr(endian) >= mem_range.start_phys_addr && h.p_paddr(endian) < mem_range.end_phys_addr) {
@@ -383,9 +384,9 @@ impl DumpItForLinux  {
 
                     let start_phys_addr = mem_range.start_phys_addr + delta;
                     let memsz = h.p_filesz(endian);
-                    assert!(h.p_filesz(endian) == h.p_memsz(endian));
+                    assert_eq!(h.p_filesz(endian), h.p_memsz(endian));
                     if !is_virtual {
-                        assert!(memsz == mem_range.memsz);
+                        assert_eq!(memsz, mem_range.memsz);
                     }
                     let end_phys_addr = start_phys_addr + memsz;
                     let virt_addr = h.p_vaddr(endian);

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,7 +368,7 @@ impl DumpItForLinux  {
         let mut out_file_off = 0;
         for h in headers {
             // This should always be true.
-            assert!(h.p_filesz(endian) == h.p_memsz(endian));
+            assert_eq!(h.p_filesz(endian), h.p_memsz(endian));
 
             // NOTE: There is an issue on Amazon Linux and Ubuntu VMs where physaddr
             // is null when looking at "readelf -l /proc/kcore"


### PR DESCRIPTION
Issue #4 is caused by the segment size inside `/proc/iomem` for the memory range starting at `0x1000` being different from the segment from `/proc/kcore`'s header by `0x800` bytes for some reason. This is not an issue with the code as reading `/proc/iomem` and dumping the header of `/proc/kcore` using `readelf` confirms this discrepancy. This pull request fixes this issue by warning instead of panicking if the segment sizes differ and uses the max between the two to dump, ensuring that no data is lost because of the mismatch.

### DumpItForLinux Output
<pre>
mem_range: MemoryRange {
    start_phys_addr: 0x1000,
    end_phys_addr: 0x9E800,
    memsz: 0x9D800,
    virt_addr: 0x0,
    kcore_file_off: 0x0,
    out_file_off: 0x0,
    p_flags: 0x0,
    is_virtual: false,
}
delta: 0x0, is_virtual: false, start_phys_addr: 0x1000, memsz: 0x9D000
<b>memsz: 0x9D000, mem_range.memsz: 0x9D800</b>
</pre>

### readelf -a /proc/kcore
<pre>
Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  NOTE           0x00000000000002e0 0x0000000000000000 0x0000000000000000
                 0x00000000000026f4 0x0000000000000000         0x0
  LOAD           0x00007fff90e03000 0xffffffff90e00000 0x00000000a6400000
                 0x0000000002c30000 0x0000000002c30000  RWE    0x1000
  LOAD           0x00001ad980003000 0xffff9ad980000000 0xffffffffffffffff
                 0x00001fffffffffff 0x00001fffffffffff  RWE    0x1000
  LOAD           0x00007fffc0003000 0xffffffffc0000000 0xffffffffffffffff
                 0x000000003f000000 0x000000003f000000  RWE    0x1000
  LOAD           0x00000bd340004000 0xffff8bd340001000 0x0000000000001000
                 <b>0x000000000009d000 0x000000000009d000</b>  RWE    0x1000
</pre>

### cat /proc/iomem
<pre>
00000000-00000fff : Reserved
<b>00001000-0009e7ff : System RAM</b>
</pre>