### PR TITLE
Add --pipe flag to write output to a named pipe instead of a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "pkg-config",
  "tabled",
  "tar",
+ "unix-named-pipe",
  "vergen",
  "zstd",
 ]
@@ -239,6 +240,27 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -863,6 +885,16 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unix-named-pipe"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad653da8f36ac5825ba06642b5a3cce14a4e52c6a5fab4a8928d53f4426dae2"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ object = {version = "0.29.0", features = ["read", "write"]}
 tabled = "0.8.0"
 tar = "0.4.38"
 zstd = "0.11.2"
+unix-named-pipe = "0.2"
 
 [build-dependencies]
 anyhow = "1.0.65"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ More information can be found on the [Ubuntu Documentation](https://ubuntu.com/s
 ## Usage
 ### CLI Usage
 ```
-DumpIt (For Linux - x64 & ARM64) v0.1.0-8-gbcbb4e8 (2022-10-09T04:48:11Z)
+DumpIt (For Linux - x64 & ARM64) 0.1.0 (2023-01-27T13:42:56Z)
 Linux memory acquisition that makes sense.
 Copyright (c) 2022, Magnet Forensics, Inc.
 
@@ -36,12 +36,13 @@ A program that makes memory analysis for incident response easy, scalable and pr
 Usage: dumpitforlinux [OPTIONS] [Output Path]
 
 Arguments:
-  [Output Path]  Path to the output archive or file
+  [Output Path]  Path to the output archive, file, or named pipe
 
 Options:
   -0, --to-stdout  Write to stdout instead of a file
   -r, --raw        Create a single core dump file instead of a compressed archive
   -v, --verbose    Print extra output while parsing
+  -p, --pipe       Writes output to a named pipe. Note that if DumpIt is set to write an archive, it will write the archive to the pipe
   -h, --help       Print help information
   -V, --version    Print version information
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,10 +70,10 @@ struct Args {
     /// Print extra output while parsing
     #[clap(short, long)]
     verbose: bool,
-    /// Is output path a named pipe
-    #[clap(long)]
+    /// Writes output to a named pipe. Note that if DumpIt is set to write an archive, it will write the archive to the pipe
+    #[clap(short, long)]
     pipe: bool,
-    /// Path to the output archive or file.
+    /// Path to the output archive, file, or named pipe.
     #[clap(value_name = "Output Path")]
     output_path: Option<String>,
 }


### PR DESCRIPTION
This PR adds a new `--pipe` flag which writes the dump output to a named pipe instead of a file. If the pipe does not exist, it will create it. Upon opening a pipe, it will block until a reader is attached.